### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @jackwotherspoon @kiranwoth


### PR DESCRIPTION
Adding a `CODEOWNERS` file. This will auto-assign us as reviewers on any pull requests.

To learn more about how `CODEOWNERS` works see [About Code Owners](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)

Related to #2 