### PR TITLE
feat: add create expense endpoint

### DIFF
--- a/src/app/main.py
+++ b/src/app/main.py
@@ -1,8 +1,28 @@
 from fastapi import FastAPI
 
+from . import schemas
+
 app = FastAPI()
+
+# will use dictionary until database is integrated
+expenses = {
+    "8509e457-f491-46b5-bad1-e8d0504db2bb": {
+        "cost": 80.0,
+        "description": "Gas fill up",
+        "category": "Gas",
+        "id": "8509e457-f491-46b5-bad1-e8d0504db2bb",
+        "time_created": "2023-06-18T15:56:46.218431+00:00",
+    }
+}
 
 
 @app.get("/")
 async def root():
     return "Hello World"
+
+
+@app.post("/expenses/", response_model=schemas.Expense)
+async def create_expense(expense: schemas.ExpenseCreate):
+    new_expense = schemas.Expense(**expense.dict())
+    expenses[new_expense.id] = new_expense
+    return new_expense

--- a/src/app/schemas.py
+++ b/src/app/schemas.py
@@ -1,13 +1,20 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
-from uuid import UUID
+from uuid import UUID, uuid4
 
 from pydantic import BaseModel
 
 
-class Expense(BaseModel):
-    id: UUID
+class ExpenseBase(BaseModel):
     cost: float
-    time_created: datetime
     description: Optional[str] = None
     category: str = "Misc"
+
+
+class ExpenseCreate(ExpenseBase):
+    pass
+
+
+class Expense(ExpenseBase):
+    id: UUID = uuid4()
+    time_created: datetime = datetime.now(tz=timezone.utc)


### PR DESCRIPTION
Adding `POST` route for Create endpoint for Expense.

Using a dictionary to store expenses until we decide on and integrate a database to store the data.

Closes #13 